### PR TITLE
fix: shrink all nans to int8

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The `repack_frame()` method simply does this across every column in your DataFra
 
 ## Releases
 
+- `0.1.2`:
+    - Shrink columns with all NaNs to Int8
 - `0.1.1`:
     - Fix Python support in package metadata to support 3.8.1 onwards
 - `0.1.0`:

--- a/owid/repack/__init__.py
+++ b/owid/repack/__init__.py
@@ -91,7 +91,10 @@ def shrink_integer(s: pd.Series) -> pd.Series:
     """
     assert s.dtype.name in ("Int64", "int64", "UInt64", "uint64")
 
-    if s.isnull().any():
+    if s.isnull().all():
+        # shrink all NaNs to Int8
+        return s.astype("Int8")
+    elif s.isnull().any():
         if s.min() < 0:
             series = ["Int32", "Int16", "Int8"]
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "owid-repack"
-version = "0.1.1"
+version = "0.1.2"
 description = "Pack Pandas data frames into smaller, more memory-efficient data types."
 authors = ["Our World In Data <tech@ourworldindata.org>"]
 license = "MIT"

--- a/tests/test_repack.py
+++ b/tests/test_repack.py
@@ -206,3 +206,15 @@ def test_repack_frame_keep_dtypes():
 
     assert df2.myint.dtype.name == "float64"
     assert df2.myfloat.dtype.name == "float32"
+
+
+def test_repack_int64_all_nans():
+    s = pd.Series([np.nan, np.nan, np.nan], dtype="Int64")
+    v = repack.repack_series(s)
+    assert v.dtype.name == "Int8"
+
+
+def test_repack_float64_all_nans():
+    s = pd.Series([np.nan, np.nan, np.nan], dtype="float64")
+    v = repack.repack_series(s)
+    assert v.dtype.name == "Int8"


### PR DESCRIPTION
repack was failing for columns with all NaNs. Fix it by converting it to int8. Alternative would be using categorical with NaN values, but converting from int/float to categorical felt weird.